### PR TITLE
Mantis#1262697

### DIFF
--- a/widget/edit.controller.js
+++ b/widget/edit.controller.js
@@ -71,7 +71,7 @@ Copyright end */
         $scope.loadlistitem = function () {
             const fieldMap = {
                 [config.slaMappedOn]: 'mappedListItems',
-                [config.slaPausedOn]: 'pauseListItems'
+                [config.slaPausedOn]: 'pausedListItems'
             };
 
             $scope.fieldsArray.forEach(function (field) {

--- a/widget/edit.controller.js
+++ b/widget/edit.controller.js
@@ -69,10 +69,16 @@ Copyright end */
         }
 
         $scope.loadlistitem = function () {
-            $scope.fieldsArray.forEach(function (value, index, array) {
-                if (value.name === config.slaMappedOn || value.name === config.slaPausedOn) {
-                    picklistsService.loadPicklists(value).then(function (data) {
-                        $scope.listItems = data.options;
+            const fieldMap = {
+                [config.slaMappedOn]: 'mappedListItems',
+                [config.slaPausedOn]: 'pauseListItems'
+            };
+
+            $scope.fieldsArray.forEach(function (field) {
+                const targetField = fieldMap[field.name];
+                if (targetField) {
+                    picklistsService.loadPicklists(field).then(function (data) {
+                        $scope[targetField] = data.options;
                     });
                 }
             });

--- a/widget/edit.html
+++ b/widget/edit.html
@@ -68,7 +68,7 @@ Copyright end -->
                     <div class="form-group margin-bottom-0">
                         <select name="pauseitemvalue" id="pauseitemvalue" class="form-control"
                             data-ng-if="config.slaPausedOn.length > 0"
-                            data-ng-options="item.itemValue as item.itemValue for item in listItems"
+                            data-ng-options="item.itemValue as item.itemValue for item in pauseListItems"
                             data-ng-model="config.pausedItemvalue" required>
                             <option value="">{{ ::'APP.LABEL.SELECT_AN_OPTION' | translate }} </option>
                         </select>
@@ -118,7 +118,7 @@ Copyright end -->
                     <div class="form-group margin-bottom-0">
                         <select name="metitemvalue" id="metitemvalue" class="form-control"
                             data-ng-if="config.slaMappedOn.length > 0"
-                            data-ng-options="item.itemValue as item.itemValue for item in listItems"
+                            data-ng-options="item.itemValue as item.itemValue for item in mappedListItems"
                             data-ng-model="config.metItemvalue" required>
                             <option value="">{{ ::'APP.LABEL.SELECT_AN_OPTION' | translate }} </option>
                         </select>

--- a/widget/edit.html
+++ b/widget/edit.html
@@ -68,7 +68,7 @@ Copyright end -->
                     <div class="form-group margin-bottom-0">
                         <select name="pauseitemvalue" id="pauseitemvalue" class="form-control"
                             data-ng-if="config.slaPausedOn.length > 0"
-                            data-ng-options="item.itemValue as item.itemValue for item in pauseListItems"
+                            data-ng-options="item.itemValue as item.itemValue for item in pausedListItems"
                             data-ng-model="config.pausedItemvalue" required>
                             <option value="">{{ ::'APP.LABEL.SELECT_AN_OPTION' | translate }} </option>
                         </select>


### PR DESCRIPTION
## Mantis #1262697

### Issue Details

* When **Paused SLA** is configured for one picklist and **Stop SLA** for another, selecting a value for **Paused SLA** resets and instead shows the values from the **Stop SLA** picklist.

<img width="1920" height="919" alt="2" src="https://github.com/user-attachments/assets/cb77773c-306b-4467-a63e-dc762666c4dc" />

### Root Cause

* The picklist values for both **Paused SLA** and **Stop SLA** were being stored in the **same scope variable**, causing one to overwrite the other.

### Fix

* Updated the code to use **separate variables for each field**, preventing the values from overriding each other.
